### PR TITLE
Added missing source_files directive

### DIFF
--- a/ios/RCTMapboxGL.podspec
+++ b/ios/RCTMapboxGL.podspec
@@ -14,5 +14,6 @@ Pod::Spec.new do |s|
 
   s.vendored_frameworks = 'Mapbox.framework'
   s.module_name = 'Mapbox'
+  s.source_files        = "RCTMapboxGL/RCTMapboxGL.{h,m}", "RCTMapboxGL/RCTMapboxGLManager.{h,m}"
 
 end


### PR DESCRIPTION
Hey there,

The CocoaPod installation is currently not working; - only the MapBox framework is being linked (the RTC bridge hasn't been included).

